### PR TITLE
chore(deps): renovate org-preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,35 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openmcp-project/.github:renovate-config"
-  ],
-  "git-submodules": {
-    "enabled": true
-  },
-  "packageRules": [
-    {
-      "description": "Automerge submodule update",
-      "automerge": true,
-      "matchPackageNames": [
-        "hack/common"
-      ]
-    },
-    {
-      "description": "Update and automerge all components from openmcp-project immediately in one singe PR",
-      "matchManagers": [
-        "gomod"
-      ],
-      "groupName": "openmcp-project Go dependencies",
-      "groupSlug": "openmcp-go-deps",
-      "automerge": true,
-      "automergeType": "pr",
-      "prPriority": 10,
-      "semanticCommitType": "chore",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "enabled": true,
-      "matchPackageNames": [
-        "/^github.com/openmcp-project//"
-      ]
-    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,31 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openmcp-project/.github:renovate-config"
+  ],
   "git-submodules": {
     "enabled": true
   },
-  "extends": [
-    "config:recommended",
-    "config:best-practices",
-    "security:openssf-scorecard",
-    "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs"
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ],
   "packageRules": [
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "matchDepTypes": [
-        "golang"
-      ],
-      "rangeStrategy": "bump"
-    },
     {
       "description": "Automerge submodule update",
       "automerge": true,
@@ -50,14 +31,6 @@
       "matchPackageNames": [
         "/^github.com/openmcp-project//"
       ]
-    },
-    {
-      "description": "Group openmcp-project/build submodule and workflow updates",
-      "matchDepNames": [
-        "hack/common",
-        "openmcp-project/build"
-      ],
-      "groupName": "openmcp-project/build"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `renovate.json` to `.github/renovate.json` and references the new org-level preset
- `extends`: recommended + best-practices + openssf-scorecard + pinGitHubActionDigests + rebaseStalePrs
- `postUpdateOptions`: gomodTidy
- golang `rangeStrategy: bump` rule
- `openmcp-project/build` group rule
- `openmcp-project` Go dependencies grouped into one PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other dependency

```